### PR TITLE
Fix touch events to nested views

### DIFF
--- a/app/src/main/java/copyapp/scroll2d_tut/OuterHorizontalScrollView.java
+++ b/app/src/main/java/copyapp/scroll2d_tut/OuterHorizontalScrollView.java
@@ -28,14 +28,14 @@ public class OuterHorizontalScrollView extends HorizontalScrollView {
     @Override
     public boolean onInterceptTouchEvent(MotionEvent ev) {
         super.onInterceptTouchEvent(ev);
-        scrollView.onInterceptTouchEvent(ev);
+        scrollView.onInterceptTouchEvent(MotionEvent.obtain(ev.getDownTime(), ev.getEventTime(), ev.getAction(), ev.getX() + getScrollX(), ev.getY(), ev.getMetaState()));
         return true;
     }
 
     @Override
     public boolean onTouchEvent(MotionEvent ev) {
         super.onTouchEvent(ev);
-        scrollView.dispatchTouchEvent(ev);
+        scrollView.dispatchTouchEvent(MotionEvent.obtain(ev.getDownTime(), ev.getEventTime(), ev.getAction(), ev.getX() + getScrollX(), ev.getY(), ev.getMetaState()));
         return true;
     }
 }


### PR DESCRIPTION
Thanks for this code, but I did find a bug when attempting to use it.

If the inner ScrollView contains views that take a TouchEvent (buttons, etc.), then they will get the TouchEvent at the wrong place, because I guess TouchEvent is relative to the viewport. Adding the X scrolling offset before passing the TouchEvent down fixes this. If you were to nest Horizontal inside Vertical instead, I imagine you would have to instead add the Y scrolling offset to the Y coordinate.